### PR TITLE
Add env var based config and API key injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Environment variable definitions
+.env
+
+# Uploaded files
+uploads/
+
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# SistemaDenunciaCompleto2
+
+Este projeto utiliza variáveis de ambiente para a configuração do banco de dados e para a chave da API do LocationIQ.
+
+## Variáveis de ambiente
+
+Defina as seguintes variáveis antes de executar a aplicação:
+
+- `DB_HOST`  – endereço do servidor MySQL
+- `DB_USER`  – usuário do banco
+- `DB_PASSWORD` – senha do banco
+
+Exemplo de definição em um shell:
+
+```bash
+export DB_HOST=localhost
+export DB_USER=meu_usuario
+export DB_PASSWORD=minha_senha
+```
+
+## Chave do LocationIQ
+
+Os arquivos `public/js/map.js` e `public/js/novo_map.js` esperam que a chave da API seja atribuída à variável global `LOCATIONIQ_KEY`. Inclua um bloco de script antes de carregar esses arquivos:
+
+```html
+<script>
+  window.LOCATIONIQ_KEY = 'sua-chave-locationiq';
+</script>
+<script src="js/novo_map.js"></script>
+```
+
+Os uploads de imagens são gravados no diretório `uploads/`, que está listado no `.gitignore` para evitar o versionamento desses arquivos.
+

--- a/config/db.php
+++ b/config/db.php
@@ -1,8 +1,16 @@
 <?php 
-function conectarBanco() {        
-    $usuario = 'root';
-    $senha = '030212079945472989915071';
-    $servidor = 'localhost';
+/**
+ * Cria e retorna uma conexão PDO utilizando credenciais definidas por variáveis de ambiente.
+ *
+ * Variáveis de ambiente esperadas:
+ *   DB_HOST     Endereço do servidor MySQL.
+ *   DB_USER     Usuário do banco de dados.
+ *   DB_PASSWORD Senha do banco de dados.
+ */
+function conectarBanco() {
+    $usuario = getenv('DB_USER');
+    $senha = getenv('DB_PASSWORD');
+    $servidor = getenv('DB_HOST');
     $banco = 'proj';
 
     try {

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -1,4 +1,5 @@
-    const locationIQKey = 'pk.1294728d1a09262d5659d1c2475b2b2c';
+    // Espera que a chave esteja definida em window.LOCATIONIQ_KEY
+    const locationIQKey = window.LOCATIONIQ_KEY;
 
     var map = L.map('map').setView([-15.77972, -47.92972], 13);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { attribution: '© OpenStreetMap' }).addTo(map);

--- a/public/js/novo_map.js
+++ b/public/js/novo_map.js
@@ -1,4 +1,5 @@
-const locationIQKey = 'pk.1294728d1a09262d5659d1c2475b2b2c';
+// Espera que a chave esteja definida em window.LOCATIONIQ_KEY
+const locationIQKey = window.LOCATIONIQ_KEY;
 
 var map = L.map('map').setView([-15.77972, -47.92972], 13);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { attribution: '© OpenStreetMap' }).addTo(map);


### PR DESCRIPTION
## Summary
- configure `config/db.php` to read DB creds from environment variables
- introduce placeholder global variable for LocationIQ key in `map.js` and `novo_map.js`
- document environment variables and API key injection in new README
- ignore env files and uploaded images with `.gitignore`

## Testing
- `php -l config/db.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f762e8a0c832ba0685c78cc762bbe