### PR TITLE
Add viewport meta tags

### DIFF
--- a/public/admin_denuncias.php
+++ b/public/admin_denuncias.php
@@ -43,6 +43,7 @@ $denuncias = $stmt->fetchAll(PDO::FETCH_ASSOC);
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Painel Administrativo</title>
     <link rel="stylesheet" href="css/admin_denuncias.css">
     <link rel="stylesheet" href="css/header.css">

--- a/public/detalhes_denuncia.php
+++ b/public/detalhes_denuncia.php
@@ -52,6 +52,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && !empty($_POST['comentario'])) {
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Detalhes da Denúncia</title>
     <link rel="stylesheet" href="css/feed.css">
     <link rel="stylesheet" href="css/header.css">

--- a/public/minhas_denuncias.php
+++ b/public/minhas_denuncias.php
@@ -28,6 +28,7 @@ $denuncias = $stmt->fetchAll(PDO::FETCH_ASSOC);
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Minhas Denúncias</title>
     <link rel="stylesheet" href="css/feed.css">
     <link rel="stylesheet" href="css/header.css">

--- a/public/nova_denuncia.php
+++ b/public/nova_denuncia.php
@@ -18,6 +18,7 @@ $erro = "";
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Nova Denúncia</title>
     <link rel="stylesheet" href="css/feed.css">
     <link rel="stylesheet" href="css/header.css">

--- a/public/todas_denuncias.php
+++ b/public/todas_denuncias.php
@@ -23,6 +23,7 @@ $denuncias = $stmt->fetchAll(PDO::FETCH_ASSOC);
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Todas as Denúncias</title>
     <link rel="stylesheet" href="css/feed.css">
     <link rel="stylesheet" href="css/header.css">


### PR DESCRIPTION
## Summary
- add viewport metadata to all public PHP pages for consistent mobile rendering

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f78470238832b945da0e0a2b2fa1b